### PR TITLE
Bugfix/optimize cms integrity cron

### DIFF
--- a/docs/NOTION_CMS.md
+++ b/docs/NOTION_CMS.md
@@ -176,6 +176,15 @@ CLOUDINARY_API_SECRET=...
 CLOUDINARY_CMS_COVERS_FOLDER=bp-portfolio/articles
 # Optional cap for cron cover-regeneration throughput.
 CMS_COVER_REGEN_CRON_LIMIT=2
+# Integrity cron runtime tuning:
+# - full: run projection + quality gate + auto-heal + reconcile + watchdog every run
+# - incremental: run projection-only on most cron invocations
+CMS_INTEGRITY_FORCE_MODE=
+# When running via Vercel cron and force mode is unset, run one full integrity pass
+# every N scheduled windows (default: 6 => hourly when cron is every 10 minutes).
+CMS_INTEGRITY_DEEP_RUN_INTERVAL=6
+# Optional phase offset for deep windows.
+CMS_INTEGRITY_DEEP_RUN_OFFSET=0
 # Error-log retention settings (archive old rows).
 CMS_AUTOMATION_ERRORS_RETENTION_DAYS=30
 CMS_AUTOMATION_ERRORS_RETENTION_LIMIT=100
@@ -280,6 +289,9 @@ Vercel cron cadence (current):
 - `/api/cron/cms-tech-curation` weekly Monday at 18:30 UTC.
 - `/api/cron/cms-projection` retained as a compatibility alias.
 - `/api/cron/cms-automation` retained for manual full-run execution.
+- `/api/cron/cms-integrity` supports explicit overrides:
+  - `?deep=1` or `?mode=full` forces full integrity workflow.
+  - `?deep=0` or `?mode=incremental` forces projection-only workflow.
 
 Cache invalidation behavior:
 

--- a/src/app/api/cron/cms-integrity/route.test.ts
+++ b/src/app/api/cron/cms-integrity/route.test.ts
@@ -187,6 +187,26 @@ describe('GET /api/cron/cms-integrity', () => {
     })
   })
 
+  it('honors CMS_INTEGRITY_FORCE_MODE=full over query and user-agent', async () => {
+    process.env.CMS_INTEGRITY_FORCE_MODE = 'full'
+
+    const response = await GET(
+      buildRequest(
+        'http://localhost/api/cron/cms-integrity?mode=incremental&deep=0',
+        'Mozilla/5.0 local-manual-run',
+      ),
+    )
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body.mode).toBe('full')
+    expect(mocks.runProjectionCronAutomation).toHaveBeenCalledWith({
+      includeQualityGate: true,
+      includeReconcile: true,
+      includeWebhookWatchdog: true,
+    })
+  })
+
   it('returns 500 when projection automation throws', async () => {
     mocks.runProjectionCronAutomation.mockRejectedValueOnce(
       new Error('Projection exploded'),
@@ -200,6 +220,11 @@ describe('GET /api/cron/cms-integrity', () => {
     expect(response.status).toBe(500)
     expect(body).toMatchObject({
       ok: false,
+      error: 'Projection exploded',
+    })
+    expect(mocks.logAutomationErrorToNotion).toHaveBeenCalledWith({
+      workflow: 'cms-cron-integrity',
+      endpoint: '/api/cron/cms-integrity',
       error: 'Projection exploded',
     })
   })

--- a/src/app/api/cron/cms-integrity/route.test.ts
+++ b/src/app/api/cron/cms-integrity/route.test.ts
@@ -183,6 +183,29 @@ describe('GET /api/cron/cms-integrity', () => {
     })
   })
 
+  it('mode overrides deep when both are provided', async () => {
+    process.env.CMS_INTEGRITY_DEEP_RUN_INTERVAL = '1'
+    vi.spyOn(Date, 'now').mockReturnValue(20 * 60 * 1000)
+
+    const response = await GET(
+      buildRequest(
+        'http://localhost/api/cron/cms-integrity?mode=incremental&deep=1',
+      ),
+    )
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body.mode).toBe('incremental')
+    expect(mocks.runProjectionCronAutomation).toHaveBeenCalledWith({
+      includeQualityGate: false,
+      includeReconcile: false,
+      includeWebhookWatchdog: false,
+      errorLogWorkflow: 'cms-cron-integrity',
+      errorLogEndpoint: '/api/cron/cms-integrity',
+      skipReason: 'Disabled for incremental integrity run',
+    })
+  })
+
   it('respects CMS_INTEGRITY_DEEP_RUN_OFFSET', async () => {
     process.env.CMS_INTEGRITY_DEEP_RUN_INTERVAL = '3'
     process.env.CMS_INTEGRITY_DEEP_RUN_OFFSET = '2'

--- a/src/app/api/cron/cms-integrity/route.test.ts
+++ b/src/app/api/cron/cms-integrity/route.test.ts
@@ -37,6 +37,7 @@ describe('GET /api/cron/cms-integrity', () => {
     delete process.env.CMS_REVALIDATE_SECRET
     delete process.env.CMS_INTEGRITY_FORCE_MODE
     delete process.env.CMS_INTEGRITY_DEEP_RUN_OFFSET
+    mocks.logAutomationErrorToNotion.mockResolvedValue(undefined)
     mocks.runProjectionCronAutomation.mockResolvedValue({
       ok: true,
       startedAt: '2026-03-14T00:00:00.000Z',
@@ -148,6 +149,24 @@ describe('GET /api/cron/cms-integrity', () => {
     })
   })
 
+  it('respects explicit mode=incremental query override', async () => {
+    process.env.CMS_INTEGRITY_DEEP_RUN_INTERVAL = '1'
+    vi.spyOn(Date, 'now').mockReturnValue(20 * 60 * 1000)
+
+    const response = await GET(
+      buildRequest('http://localhost/api/cron/cms-integrity?mode=incremental'),
+    )
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body.mode).toBe('incremental')
+    expect(mocks.runProjectionCronAutomation).toHaveBeenCalledWith({
+      includeQualityGate: false,
+      includeReconcile: false,
+      includeWebhookWatchdog: false,
+    })
+  })
+
   it('honors CMS_INTEGRITY_FORCE_MODE over query and user-agent', async () => {
     process.env.CMS_INTEGRITY_FORCE_MODE = 'incremental'
 
@@ -165,6 +184,23 @@ describe('GET /api/cron/cms-integrity', () => {
       includeQualityGate: false,
       includeReconcile: false,
       includeWebhookWatchdog: false,
+    })
+  })
+
+  it('returns 500 when projection automation throws', async () => {
+    mocks.runProjectionCronAutomation.mockRejectedValueOnce(
+      new Error('Projection exploded'),
+    )
+
+    const response = await GET(
+      buildRequest('http://localhost/api/cron/cms-integrity'),
+    )
+    const body = await response.json()
+
+    expect(response.status).toBe(500)
+    expect(body).toMatchObject({
+      ok: false,
+      error: 'Projection exploded',
     })
   })
 })

--- a/src/app/api/cron/cms-integrity/route.test.ts
+++ b/src/app/api/cron/cms-integrity/route.test.ts
@@ -69,6 +69,9 @@ describe('GET /api/cron/cms-integrity', () => {
       includeQualityGate: false,
       includeReconcile: false,
       includeWebhookWatchdog: false,
+      errorLogWorkflow: 'cms-cron-integrity',
+      errorLogEndpoint: '/api/cron/cms-integrity',
+      skipReason: 'Disabled for incremental integrity run',
     })
   })
 
@@ -107,6 +110,9 @@ describe('GET /api/cron/cms-integrity', () => {
       includeQualityGate: true,
       includeReconcile: true,
       includeWebhookWatchdog: true,
+      errorLogWorkflow: 'cms-cron-integrity',
+      errorLogEndpoint: '/api/cron/cms-integrity',
+      skipReason: 'Disabled for incremental integrity run',
     })
   })
 
@@ -128,6 +134,9 @@ describe('GET /api/cron/cms-integrity', () => {
       includeQualityGate: true,
       includeReconcile: true,
       includeWebhookWatchdog: true,
+      errorLogWorkflow: 'cms-cron-integrity',
+      errorLogEndpoint: '/api/cron/cms-integrity',
+      skipReason: 'Disabled for incremental integrity run',
     })
   })
 
@@ -146,6 +155,9 @@ describe('GET /api/cron/cms-integrity', () => {
       includeQualityGate: true,
       includeReconcile: true,
       includeWebhookWatchdog: true,
+      errorLogWorkflow: 'cms-cron-integrity',
+      errorLogEndpoint: '/api/cron/cms-integrity',
+      skipReason: 'Disabled for incremental integrity run',
     })
   })
 
@@ -164,6 +176,9 @@ describe('GET /api/cron/cms-integrity', () => {
       includeQualityGate: false,
       includeReconcile: false,
       includeWebhookWatchdog: false,
+      errorLogWorkflow: 'cms-cron-integrity',
+      errorLogEndpoint: '/api/cron/cms-integrity',
+      skipReason: 'Disabled for incremental integrity run',
     })
   })
 
@@ -184,6 +199,9 @@ describe('GET /api/cron/cms-integrity', () => {
       includeQualityGate: false,
       includeReconcile: false,
       includeWebhookWatchdog: false,
+      errorLogWorkflow: 'cms-cron-integrity',
+      errorLogEndpoint: '/api/cron/cms-integrity',
+      skipReason: 'Disabled for incremental integrity run',
     })
   })
 
@@ -204,6 +222,9 @@ describe('GET /api/cron/cms-integrity', () => {
       includeQualityGate: true,
       includeReconcile: true,
       includeWebhookWatchdog: true,
+      errorLogWorkflow: 'cms-cron-integrity',
+      errorLogEndpoint: '/api/cron/cms-integrity',
+      skipReason: 'Disabled for incremental integrity run',
     })
   })
 

--- a/src/app/api/cron/cms-integrity/route.test.ts
+++ b/src/app/api/cron/cms-integrity/route.test.ts
@@ -1,0 +1,170 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  runProjectionCronAutomation: vi.fn(),
+  logAutomationErrorToNotion: vi.fn(),
+  revalidateArticleSurfaces: vi.fn(),
+}))
+
+vi.mock('@/lib/cms/notion/cronAutomation', () => ({
+  runProjectionCronAutomation: mocks.runProjectionCronAutomation,
+}))
+
+vi.mock('@/lib/cms/notion/automationErrorLog', () => ({
+  logAutomationErrorToNotion: mocks.logAutomationErrorToNotion,
+}))
+
+vi.mock('../_revalidate', () => ({
+  revalidateArticleSurfaces: mocks.revalidateArticleSurfaces,
+}))
+
+import { GET } from './route'
+
+function buildRequest(url: string, userAgent = 'vercel-cron/1.0') {
+  return new Request(url, {
+    method: 'GET',
+    headers: {
+      Authorization: 'Bearer test-cron-secret',
+      'User-Agent': userAgent,
+    },
+  })
+}
+
+describe('GET /api/cron/cms-integrity', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    process.env.CRON_SECRET = 'test-cron-secret'
+    delete process.env.CMS_REVALIDATE_SECRET
+    delete process.env.CMS_INTEGRITY_FORCE_MODE
+    delete process.env.CMS_INTEGRITY_DEEP_RUN_OFFSET
+    mocks.runProjectionCronAutomation.mockResolvedValue({
+      ok: true,
+      startedAt: '2026-03-14T00:00:00.000Z',
+      errors: [],
+    })
+  })
+
+  afterEach(() => {
+    delete process.env.CRON_SECRET
+    delete process.env.CMS_REVALIDATE_SECRET
+    delete process.env.CMS_INTEGRITY_FORCE_MODE
+    delete process.env.CMS_INTEGRITY_DEEP_RUN_INTERVAL
+    delete process.env.CMS_INTEGRITY_DEEP_RUN_OFFSET
+    vi.restoreAllMocks()
+  })
+
+  it('uses incremental mode for routine vercel cron runs', async () => {
+    process.env.CMS_INTEGRITY_DEEP_RUN_INTERVAL = '2'
+    vi.spyOn(Date, 'now').mockReturnValue(10 * 60 * 1000)
+
+    const response = await GET(
+      buildRequest('http://localhost/api/cron/cms-integrity'),
+    )
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body.mode).toBe('incremental')
+    expect(mocks.runProjectionCronAutomation).toHaveBeenCalledWith({
+      includeQualityGate: false,
+      includeReconcile: false,
+      includeWebhookWatchdog: false,
+    })
+  })
+
+  it('returns 401 for unauthorized requests', async () => {
+    const request = new Request('http://localhost/api/cron/cms-integrity', {
+      method: 'GET',
+      headers: {
+        Authorization: 'Bearer wrong-secret',
+        'User-Agent': 'vercel-cron/1.0',
+      },
+    })
+
+    const response = await GET(request)
+    const body = await response.json()
+
+    expect(response.status).toBe(401)
+    expect(body).toMatchObject({
+      ok: false,
+      error: 'Unauthorized',
+    })
+    expect(mocks.runProjectionCronAutomation).not.toHaveBeenCalled()
+  })
+
+  it('respects explicit mode=full query override', async () => {
+    process.env.CMS_INTEGRITY_DEEP_RUN_INTERVAL = '999'
+    vi.spyOn(Date, 'now').mockReturnValue(10 * 60 * 1000)
+
+    const response = await GET(
+      buildRequest('http://localhost/api/cron/cms-integrity?mode=full'),
+    )
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body.mode).toBe('full')
+    expect(mocks.runProjectionCronAutomation).toHaveBeenCalledWith({
+      includeQualityGate: true,
+      includeReconcile: true,
+      includeWebhookWatchdog: true,
+    })
+  })
+
+  it('defaults to full mode for non-vercel user agents', async () => {
+    process.env.CMS_INTEGRITY_DEEP_RUN_INTERVAL = '999'
+    vi.spyOn(Date, 'now').mockReturnValue(10 * 60 * 1000)
+
+    const response = await GET(
+      buildRequest(
+        'http://localhost/api/cron/cms-integrity',
+        'Mozilla/5.0 local-manual-run',
+      ),
+    )
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body.mode).toBe('full')
+    expect(mocks.runProjectionCronAutomation).toHaveBeenCalledWith({
+      includeQualityGate: true,
+      includeReconcile: true,
+      includeWebhookWatchdog: true,
+    })
+  })
+
+  it('allows explicit full runs with deep=1', async () => {
+    process.env.CMS_INTEGRITY_DEEP_RUN_INTERVAL = '999'
+    vi.spyOn(Date, 'now').mockReturnValue(20 * 60 * 1000)
+
+    const response = await GET(
+      buildRequest('http://localhost/api/cron/cms-integrity?deep=1'),
+    )
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body.mode).toBe('full')
+    expect(mocks.runProjectionCronAutomation).toHaveBeenCalledWith({
+      includeQualityGate: true,
+      includeReconcile: true,
+      includeWebhookWatchdog: true,
+    })
+  })
+
+  it('honors CMS_INTEGRITY_FORCE_MODE over query and user-agent', async () => {
+    process.env.CMS_INTEGRITY_FORCE_MODE = 'incremental'
+
+    const response = await GET(
+      buildRequest(
+        'http://localhost/api/cron/cms-integrity?mode=full&deep=1',
+        'Mozilla/5.0 local-manual-run',
+      ),
+    )
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body.mode).toBe('incremental')
+    expect(mocks.runProjectionCronAutomation).toHaveBeenCalledWith({
+      includeQualityGate: false,
+      includeReconcile: false,
+      includeWebhookWatchdog: false,
+    })
+  })
+})

--- a/src/app/api/cron/cms-integrity/route.test.ts
+++ b/src/app/api/cron/cms-integrity/route.test.ts
@@ -37,6 +37,7 @@ describe('GET /api/cron/cms-integrity', () => {
     delete process.env.CMS_REVALIDATE_SECRET
     delete process.env.CMS_INTEGRITY_FORCE_MODE
     delete process.env.CMS_INTEGRITY_DEEP_RUN_OFFSET
+    delete process.env.CMS_INTEGRITY_DEEP_RUN_INTERVAL
     mocks.logAutomationErrorToNotion.mockResolvedValue(undefined)
     mocks.runProjectionCronAutomation.mockResolvedValue({
       ok: true,

--- a/src/app/api/cron/cms-integrity/route.test.ts
+++ b/src/app/api/cron/cms-integrity/route.test.ts
@@ -182,6 +182,28 @@ describe('GET /api/cron/cms-integrity', () => {
     })
   })
 
+  it('respects CMS_INTEGRITY_DEEP_RUN_OFFSET', async () => {
+    process.env.CMS_INTEGRITY_DEEP_RUN_INTERVAL = '3'
+    process.env.CMS_INTEGRITY_DEEP_RUN_OFFSET = '2'
+    vi.spyOn(Date, 'now').mockReturnValue(10 * 60 * 1000)
+
+    const response = await GET(
+      buildRequest('http://localhost/api/cron/cms-integrity'),
+    )
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body.mode).toBe('full')
+    expect(mocks.runProjectionCronAutomation).toHaveBeenCalledWith({
+      includeQualityGate: true,
+      includeReconcile: true,
+      includeWebhookWatchdog: true,
+      errorLogWorkflow: 'cms-cron-integrity',
+      errorLogEndpoint: '/api/cron/cms-integrity',
+      skipReason: 'Disabled for incremental integrity run',
+    })
+  })
+
   it('honors CMS_INTEGRITY_FORCE_MODE over query and user-agent', async () => {
     process.env.CMS_INTEGRITY_FORCE_MODE = 'incremental'
 

--- a/src/app/api/cron/cms-integrity/route.ts
+++ b/src/app/api/cron/cms-integrity/route.ts
@@ -6,6 +6,56 @@ import { runProjectionCronAutomation } from '@/lib/cms/notion/cronAutomation'
 import { isAuthorizedCronRequest } from '../_auth'
 import { revalidateArticleSurfaces } from '../_revalidate'
 
+type IntegrityRunMode = 'full' | 'incremental'
+
+function parsePositiveInt(value: string | undefined, fallback: number) {
+  const parsed = value ? Number(value) : Number.NaN
+  if (Number.isFinite(parsed) && parsed > 0) {
+    return Math.floor(parsed)
+  }
+  return fallback
+}
+
+function resolveIntegrityRunMode(request: Request): IntegrityRunMode {
+  const forced = process.env.CMS_INTEGRITY_FORCE_MODE?.trim().toLowerCase()
+  if (forced === 'full' || forced === 'incremental') {
+    return forced
+  }
+
+  const url = new URL(request.url)
+  const mode = url.searchParams.get('mode')?.trim().toLowerCase()
+  if (mode === 'full' || mode === 'incremental') {
+    return mode
+  }
+
+  const deep = url.searchParams.get('deep')?.trim()
+  if (deep === '1' || deep === 'true') {
+    return 'full'
+  }
+  if (deep === '0' || deep === 'false') {
+    return 'incremental'
+  }
+
+  const userAgent = request.headers.get('user-agent') ?? ''
+  const isVercelCron = /vercel-cron/i.test(userAgent)
+  if (!isVercelCron) {
+    return 'full'
+  }
+
+  const interval = parsePositiveInt(
+    process.env.CMS_INTEGRITY_DEEP_RUN_INTERVAL,
+    6,
+  )
+  const offset = parsePositiveInt(process.env.CMS_INTEGRITY_DEEP_RUN_OFFSET, 0)
+  if (interval <= 1) {
+    return 'full'
+  }
+
+  // Bucket by cron-sized 10-minute windows so deep runs happen predictably.
+  const window = Math.floor(Date.now() / (10 * 60 * 1000))
+  return (window + offset) % interval === 0 ? 'full' : 'incremental'
+}
+
 // TODO(backlog): Refactor cms-projection/cms-integrity into shared cron handler.
 // Notion: https://www.notion.so/Refactor-cms-projection-cms-integrity-into-shared-cron-handler-31cbe01e1e06813f84ffeb50eedb7469
 async function run(request: Request) {
@@ -17,7 +67,13 @@ async function run(request: Request) {
   }
 
   try {
-    const result = await runProjectionCronAutomation()
+    const mode = resolveIntegrityRunMode(request)
+    const fullRun = mode === 'full'
+    const result = await runProjectionCronAutomation({
+      includeQualityGate: fullRun,
+      includeReconcile: fullRun,
+      includeWebhookWatchdog: fullRun,
+    })
     let revalidateError: string | null = null
     try {
       revalidateArticleSurfaces()
@@ -38,7 +94,9 @@ async function run(request: Request) {
       })
     }
     return NextResponse.json(
-      revalidateError ? { ...result, revalidateError } : result,
+      revalidateError
+        ? { ...result, mode, revalidateError }
+        : { ...result, mode },
       { status: result.ok && !revalidateError ? 200 : 207 },
     )
   } catch (error) {

--- a/src/app/api/cron/cms-integrity/route.ts
+++ b/src/app/api/cron/cms-integrity/route.ts
@@ -73,6 +73,9 @@ async function run(request: Request) {
       includeQualityGate: fullRun,
       includeReconcile: fullRun,
       includeWebhookWatchdog: fullRun,
+      errorLogWorkflow: 'cms-cron-integrity',
+      errorLogEndpoint: '/api/cron/cms-integrity',
+      skipReason: 'Disabled for incremental integrity run',
     })
     let revalidateError: string | null = null
     try {

--- a/src/app/api/cron/cms-projection/route.ts
+++ b/src/app/api/cron/cms-projection/route.ts
@@ -34,13 +34,10 @@ async function run(request: Request) {
         endpoint: ENDPOINT,
         error: `Revalidation failed: ${revalidateError}`,
       }).catch((logError) => {
-        console.error(
-          `[${WORKFLOW}] failed to write revalidation error log`,
-          {
-            error:
-              logError instanceof Error ? logError.message : String(logError),
-          },
-        )
+        console.error(`[${WORKFLOW}] failed to write revalidation error log`, {
+          error:
+            logError instanceof Error ? logError.message : String(logError),
+        })
       })
     }
     return NextResponse.json(

--- a/src/app/api/cron/cms-projection/route.ts
+++ b/src/app/api/cron/cms-projection/route.ts
@@ -6,6 +6,9 @@ import { runProjectionCronAutomation } from '@/lib/cms/notion/cronAutomation'
 import { isAuthorizedCronRequest } from '../_auth'
 import { revalidateArticleSurfaces } from '../_revalidate'
 
+const WORKFLOW = 'cms-cron-projection'
+const ENDPOINT = '/api/cron/cms-projection'
+
 // TODO(backlog): Refactor cms-projection/cms-integrity into shared cron handler.
 // Notion: https://www.notion.so/Refactor-cms-projection-cms-integrity-into-shared-cron-handler-31cbe01e1e06813f84ffeb50eedb7469
 async function run(request: Request) {
@@ -17,19 +20,22 @@ async function run(request: Request) {
   }
 
   try {
-    const result = await runProjectionCronAutomation()
+    const result = await runProjectionCronAutomation({
+      errorLogWorkflow: WORKFLOW,
+      errorLogEndpoint: ENDPOINT,
+    })
     let revalidateError: string | null = null
     try {
       revalidateArticleSurfaces()
     } catch (error) {
       revalidateError = error instanceof Error ? error.message : String(error)
       await logAutomationErrorToNotion({
-        workflow: 'cms-cron-projection',
-        endpoint: '/api/cron/cms-projection',
+        workflow: WORKFLOW,
+        endpoint: ENDPOINT,
         error: `Revalidation failed: ${revalidateError}`,
       }).catch((logError) => {
         console.error(
-          '[cms-cron-projection] failed to write revalidation error log',
+          `[${WORKFLOW}] failed to write revalidation error log`,
           {
             error:
               logError instanceof Error ? logError.message : String(logError),
@@ -43,11 +49,11 @@ async function run(request: Request) {
     )
   } catch (error) {
     await logAutomationErrorToNotion({
-      workflow: 'cms-cron-projection',
-      endpoint: '/api/cron/cms-projection',
+      workflow: WORKFLOW,
+      endpoint: ENDPOINT,
       error: error instanceof Error ? error.message : 'Unknown error',
     }).catch((logError) => {
-      console.error('[cms-cron-projection] failed to write Notion error log', {
+      console.error(`[${WORKFLOW}] failed to write Notion error log`, {
         error: logError instanceof Error ? logError.message : String(logError),
       })
     })

--- a/src/lib/cms/notion/cronAutomation.ts
+++ b/src/lib/cms/notion/cronAutomation.ts
@@ -88,6 +88,12 @@ async function runStep<T>(
  *
  * @param options Optional runtime controls.
  * @param options.logErrors When false, suppresses Notion error-log writes.
+ * @param options.includeQualityGate When false, skips quality-gate,
+ * auto-heal, and quality-gate recheck steps. Defaults to true.
+ * @param options.includeReconcile When false, skips projection reconcile checks.
+ * Defaults to true.
+ * @param options.includeWebhookWatchdog When false, skips webhook ledger
+ * watchdog processing. Defaults to true.
  * @returns Automation summary (`ok`, `startedAt`, `errors`, step payloads).
  *
  * Side effects:

--- a/src/lib/cms/notion/cronAutomation.ts
+++ b/src/lib/cms/notion/cronAutomation.ts
@@ -190,7 +190,24 @@ export async function runProjectionCronAutomation(options?: {
         })
       }
     } else {
-      summary.qualityGate = {
+      summary.qualityGateBefore = {
+        stepSkipped: true,
+        skipped: true,
+        reason: skipReason,
+      }
+      summary.autoHeal = {
+        stepSkipped: true,
+        ok: true,
+        scanned: 0,
+        checkedPublishSafe: 0,
+        healed: 0,
+        skipped: 0,
+        errors: [],
+        status: 'skipped',
+        reason: skipReason,
+      }
+      summary.qualityGateAfter = {
+        stepSkipped: true,
         skipped: true,
         reason: skipReason,
       }
@@ -220,6 +237,12 @@ export async function runProjectionCronAutomation(options?: {
       }
     } else {
       summary.reconcile = {
+        stepSkipped: true,
+        ok: true,
+        checkedSource: 0,
+        checkedTargets: 0,
+        checkedCalendarRows: 0,
+        findings: [],
         skipped: true,
         reason: skipReason,
       }
@@ -246,6 +269,13 @@ export async function runProjectionCronAutomation(options?: {
       }
     } else {
       summary.watchdog = {
+        stepSkipped: true,
+        ok: true,
+        enabled: false,
+        scanned: 0,
+        staleFound: 0,
+        markedFailed: 0,
+        errors: [],
         skipped: true,
         reason: skipReason,
       }

--- a/src/lib/cms/notion/cronAutomation.ts
+++ b/src/lib/cms/notion/cronAutomation.ts
@@ -97,10 +97,16 @@ async function runStep<T>(
  */
 export async function runProjectionCronAutomation(options?: {
   logErrors?: boolean
+  includeQualityGate?: boolean
+  includeReconcile?: boolean
+  includeWebhookWatchdog?: boolean
 }): Promise<AutomationSummary> {
   const startedAt = new Date().toISOString()
   const summary: Record<string, unknown> = {}
   const errors: AutomationIssue[] = []
+  const includeQualityGate = options?.includeQualityGate !== false
+  const includeReconcile = options?.includeReconcile !== false
+  const includeWebhookWatchdog = options?.includeWebhookWatchdog !== false
   try {
     const projectionSync = await runStep(
       'projection-sync',
@@ -117,90 +123,111 @@ export async function runProjectionCronAutomation(options?: {
       })
     }
 
-    const qualityBefore = await runStep(
-      'quality-gate-before',
-      () => evaluateSourceArticleQualityGate(),
-      summary,
-      'qualityGateBefore',
-      errors,
-    )
-
-    let autoHeal: Awaited<
-      ReturnType<typeof autoHealSourceArticleQualityGate>
-    > | null = null
-    let qualityAfter = qualityBefore
-    if (qualityBefore && !qualityBefore.ok) {
-      autoHeal = await runStep(
-        'auto-heal',
-        () => autoHealSourceArticleQualityGate(),
-        summary,
-        'autoHeal',
-        errors,
-      )
-      if (autoHeal && !autoHeal.ok) {
-        errors.push({
-          step: 'auto-heal',
-          message: 'Auto-heal completed with errors',
-          details: autoHeal.errors,
-        })
-      }
-
-      qualityAfter = await runStep(
-        'quality-gate-after',
+    if (includeQualityGate) {
+      const qualityBefore = await runStep(
+        'quality-gate-before',
         () => evaluateSourceArticleQualityGate(),
         summary,
-        'qualityGateAfter',
+        'qualityGateBefore',
         errors,
       )
-    }
 
-    if (qualityAfter && !qualityAfter.ok) {
-      errors.push({
-        step: 'quality-gate',
-        message: `Quality gate still failing for ${qualityAfter.failed} source rows after remediation`,
-        details: qualityAfter.failures,
-      })
-    }
+      let autoHeal: Awaited<
+        ReturnType<typeof autoHealSourceArticleQualityGate>
+      > | null = null
+      let qualityAfter = qualityBefore
+      if (qualityBefore && !qualityBefore.ok) {
+        autoHeal = await runStep(
+          'auto-heal',
+          () => autoHealSourceArticleQualityGate(),
+          summary,
+          'autoHeal',
+          errors,
+        )
+        if (autoHeal && !autoHeal.ok) {
+          errors.push({
+            step: 'auto-heal',
+            message: 'Auto-heal completed with errors',
+            details: autoHeal.errors,
+          })
+        }
 
-    const reconcile = await runStep(
-      'reconcile',
-      () => reconcilePortfolioArticleProjection(),
-      summary,
-      'reconcile',
-      errors,
-    )
-    if (reconcile && !reconcile.ok) {
-      // Only escalate blocking reconcile issues here; non-critical findings are
-      // preserved in summary.reconcile for observability without failing the run.
-      const critical = reconcile.findings.filter(
-        (finding) => finding.severity === 'critical',
-      )
-      if (critical.length > 0) {
+        qualityAfter = await runStep(
+          'quality-gate-after',
+          () => evaluateSourceArticleQualityGate(),
+          summary,
+          'qualityGateAfter',
+          errors,
+        )
+      }
+
+      if (qualityAfter && !qualityAfter.ok) {
         errors.push({
-          step: 'reconcile',
-          message: `Reconcile found ${critical.length} critical findings`,
-          details: critical,
+          step: 'quality-gate',
+          message: `Quality gate still failing for ${qualityAfter.failed} source rows after remediation`,
+          details: qualityAfter.failures,
         })
+      }
+    } else {
+      summary.qualityGate = {
+        skipped: true,
+        reason: 'Disabled for incremental integrity run',
       }
     }
 
-    const watchdog = await runStep(
-      'webhook-watchdog',
-      () =>
-        runWebhookLedgerWatchdog({
-          staleMinutes: 90,
-          limit: 100,
-        }),
-      summary,
-      'watchdog',
-      errors,
-    )
-    if (watchdog && !watchdog.ok) {
-      errors.push({
-        step: 'webhook-watchdog',
-        message: 'Webhook watchdog completed with errors',
-        details: watchdog.errors,
-      })
+    if (includeReconcile) {
+      const reconcile = await runStep(
+        'reconcile',
+        () => reconcilePortfolioArticleProjection(),
+        summary,
+        'reconcile',
+        errors,
+      )
+      if (reconcile && !reconcile.ok) {
+        // Only escalate blocking reconcile issues here; non-critical findings are
+        // preserved in summary.reconcile for observability without failing the run.
+        const critical = reconcile.findings.filter(
+          (finding) => finding.severity === 'critical',
+        )
+        if (critical.length > 0) {
+          errors.push({
+            step: 'reconcile',
+            message: `Reconcile found ${critical.length} critical findings`,
+            details: critical,
+          })
+        }
+      }
+    } else {
+      summary.reconcile = {
+        skipped: true,
+        reason: 'Disabled for incremental integrity run',
+      }
+    }
+
+    if (includeWebhookWatchdog) {
+      const watchdog = await runStep(
+        'webhook-watchdog',
+        () =>
+          runWebhookLedgerWatchdog({
+            staleMinutes: 90,
+            limit: 100,
+          }),
+        summary,
+        'watchdog',
+        errors,
+      )
+      if (watchdog && !watchdog.ok) {
+        errors.push({
+          step: 'webhook-watchdog',
+          message: 'Webhook watchdog completed with errors',
+          details: watchdog.errors,
+        })
+      }
+    } else {
+      summary.watchdog = {
+        skipped: true,
+        reason: 'Disabled for incremental integrity run',
+      }
     }
   } catch (error) {
     errors.push({

--- a/src/lib/cms/notion/cronAutomation.ts
+++ b/src/lib/cms/notion/cronAutomation.ts
@@ -94,6 +94,12 @@ async function runStep<T>(
  * Defaults to true.
  * @param options.includeWebhookWatchdog When false, skips webhook ledger
  * watchdog processing. Defaults to true.
+ * @param options.errorLogWorkflow Optional workflow name used when writing
+ * unresolved errors to Notion. Defaults to `cms-cron-projection`.
+ * @param options.errorLogEndpoint Optional endpoint name used when writing
+ * unresolved errors to Notion. Defaults to `/api/cron/cms-projection`.
+ * @param options.skipReason Optional summary reason for disabled steps.
+ * Defaults to `Skipped by caller configuration`.
  * @returns Automation summary (`ok`, `startedAt`, `errors`, step payloads).
  *
  * Side effects:
@@ -106,6 +112,9 @@ export async function runProjectionCronAutomation(options?: {
   includeQualityGate?: boolean
   includeReconcile?: boolean
   includeWebhookWatchdog?: boolean
+  errorLogWorkflow?: string
+  errorLogEndpoint?: string
+  skipReason?: string
 }): Promise<AutomationSummary> {
   const startedAt = new Date().toISOString()
   const summary: Record<string, unknown> = {}
@@ -113,6 +122,12 @@ export async function runProjectionCronAutomation(options?: {
   const includeQualityGate = options?.includeQualityGate !== false
   const includeReconcile = options?.includeReconcile !== false
   const includeWebhookWatchdog = options?.includeWebhookWatchdog !== false
+  const errorLogWorkflow =
+    options?.errorLogWorkflow?.trim() || 'cms-cron-projection'
+  const errorLogEndpoint =
+    options?.errorLogEndpoint?.trim() || '/api/cron/cms-projection'
+  const skipReason =
+    options?.skipReason?.trim() || 'Skipped by caller configuration'
   try {
     const projectionSync = await runStep(
       'projection-sync',
@@ -177,7 +192,7 @@ export async function runProjectionCronAutomation(options?: {
     } else {
       summary.qualityGate = {
         skipped: true,
-        reason: 'Disabled for incremental integrity run',
+        reason: skipReason,
       }
     }
 
@@ -206,7 +221,7 @@ export async function runProjectionCronAutomation(options?: {
     } else {
       summary.reconcile = {
         skipped: true,
-        reason: 'Disabled for incremental integrity run',
+        reason: skipReason,
       }
     }
 
@@ -232,7 +247,7 @@ export async function runProjectionCronAutomation(options?: {
     } else {
       summary.watchdog = {
         skipped: true,
-        reason: 'Disabled for incremental integrity run',
+        reason: skipReason,
       }
     }
   } catch (error) {
@@ -243,12 +258,7 @@ export async function runProjectionCronAutomation(options?: {
     })
   } finally {
     if (options?.logErrors !== false) {
-      await writeErrorLog(
-        'cms-cron-projection',
-        '/api/cron/cms-projection',
-        errors,
-        summary,
-      )
+      await writeErrorLog(errorLogWorkflow, errorLogEndpoint, errors, summary)
     }
   }
 

--- a/src/lib/cms/notion/projectionSync.ts
+++ b/src/lib/cms/notion/projectionSync.ts
@@ -1294,6 +1294,20 @@ export async function syncPortfolioArticleProjection(options?: {
       const existing =
         targetIndex.bySourceId.get(source.id) ??
         targetIndex.bySlug.get(source.slug)
+      const existingFingerprint = existing
+        ? propertyToText(
+            getProperty(existing.properties, ['Hash / Revision Fingerprint']),
+          )
+        : ''
+      const unchangedExisting =
+        Boolean(existing) &&
+        existingFingerprint.trim() === source.revisionFingerprint
+
+      if (unchangedExisting) {
+        skipped += 1
+        continue
+      }
+
       let searchIndexText: string | undefined
 
       if (eligibleForProjection(source)) {

--- a/src/lib/cms/notion/projectionSync.ts
+++ b/src/lib/cms/notion/projectionSync.ts
@@ -1299,9 +1299,11 @@ export async function syncPortfolioArticleProjection(options?: {
             getProperty(existing.properties, ['Hash / Revision Fingerprint']),
           )
         : ''
+      const normalizedExistingFingerprint = existingFingerprint.trim()
+      const normalizedSourceFingerprint = source.revisionFingerprint.trim()
       const unchangedExisting =
         Boolean(existing) &&
-        existingFingerprint.trim() === source.revisionFingerprint
+        normalizedExistingFingerprint === normalizedSourceFingerprint
 
       if (unchangedExisting) {
         skipped += 1


### PR DESCRIPTION
# Optimize CMS integrity cron runtime with incremental mode and projection fast-path

## TL;DR

- Add `cms-integrity` run modes (`full` vs `incremental`) to reduce 300s timeout risk.
- Run deep integrity checks periodically (or via explicit override) instead of every invocation.
- Skip unchanged projection rows using revision fingerprint to reduce Notion reads/writes.
- Add route-level tests for mode resolution and authorization edge cases.

## Scope

- Cron API route behavior for `/api/cron/cms-integrity`.
- Cron automation orchestration options in Notion CMS automation layer.
- Projection sync runtime optimization path.
- Notion CMS runbook/docs updates for new env controls and query overrides.
- New unit tests for integrity cron route mode selection and auth behavior.

### Key changes

- `src/app/api/cron/cms-integrity/route.ts`
  - Introduces mode resolver:
    - `CMS_INTEGRITY_FORCE_MODE` override (`full|incremental`)
    - query overrides (`?mode=...`, `?deep=...`)
    - non-Vercel UA defaults to `full`
    - Vercel cron uses interval-based deep runs (`CMS_INTEGRITY_DEEP_RUN_INTERVAL`, `CMS_INTEGRITY_DEEP_RUN_OFFSET`)
  - Calls `runProjectionCronAutomation` with selective steps based on mode.
  - Returns selected `mode` in response payload.
- `src/lib/cms/notion/cronAutomation.ts`
  - Adds `includeQualityGate`, `includeReconcile`, `includeWebhookWatchdog` options.
  - Supports incremental projection-only path while preserving summary telemetry.
- `src/lib/cms/notion/projectionSync.ts`
  - Adds fingerprint short-circuit to skip unchanged rows before expensive block-tree fetch/write.
- `src/app/api/cron/cms-integrity/route.test.ts`
  - Adds tests for:
    - unauthorized request returns `401`
    - routine Vercel cron incremental mode behavior
    - `?mode=full` and `?deep=1` forcing full mode
    - non-Vercel user-agent defaulting to full mode
    - `CMS_INTEGRITY_FORCE_MODE` overriding query/user-agent resolution
- `docs/NOTION_CMS.md`
  - Documents new integrity cron env tuning and route query overrides.

## Why

- Production logs show repeated timeout failures at 300s on `/api/cron/cms-integrity`.
- The previous workflow ran multiple full-scan operations every 10 minutes, which is vulnerable to runtime spikes and transient Notion latency.
- Splitting deep checks from routine projection sync reduces timeout risk while preserving periodic integrity coverage.

## Risk / Mitigation

- **Risk:** Incremental runs can delay detection/remediation of quality/reconcile/watchdog issues between deep runs.  
  **Mitigation:** Deep run interval defaults to hourly (`6` windows on 10-minute cron), plus explicit `?mode=full`/`?deep=1` support and force mode env override.

- **Risk:** Fingerprint skip may reduce self-healing of target drift for unchanged source rows (e.g., incomplete/stale projection fields).  
  **Mitigation:** Monitor post-deploy integrity findings and consider a follow-up guard to bypass skip for rows missing required target fields/search index.

- **Risk:** Mode resolution precedence could be misunderstood operationally.  
  **Mitigation:** Added tests and docs clarifying precedence and override behavior.

---

## How to Test (Reviewer Checklist)

1. Run unit tests:
   - `npm run test -- src/app/api/cron/cms-integrity/route.test.ts`
2. Validate auth behavior:
   - Call `/api/cron/cms-integrity` with invalid bearer token and confirm `401`.
3. Validate mode resolution:
   - Call with `?mode=full` and confirm response includes `"mode":"full"` and full-step options.
   - Call from non-Vercel UA and confirm `"mode":"full"`.
   - Set `CMS_INTEGRITY_FORCE_MODE=incremental`, call with `?mode=full`, confirm `"mode":"incremental"`.
4. (Optional in staging/prod) Observe cron logs for reduced timeout frequency and lower runtime.
5. Run lint:
   - `npm run lint` (expect existing unrelated warnings in `.tmp-article-backfill-once.mjs`).

---

## Breaking Changes?

- [ ] Yes
- [x] No

---

## Release Notes

- Improved reliability of Notion CMS integrity cron by introducing incremental execution mode and configurable deep-run cadence to avoid Vercel 300s timeout failures.

## Rollback Plan

- Revert this PR.
- Confirm `/api/cron/cms-integrity` returns to prior always-full behavior.
- Remove/ignore new env vars:
  - `CMS_INTEGRITY_FORCE_MODE`
  - `CMS_INTEGRITY_DEEP_RUN_INTERVAL`
  - `CMS_INTEGRITY_DEEP_RUN_OFFSET`
- Monitor cron logs to verify pre-change execution pattern is restored.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable CMS integrity run modes (full vs incremental) via environment and query overrides; runtime flags to disable quality-gate, reconcile, and webhook watchdog steps.

* **Improvements**
  * Projection sync now skips unchanged content to reduce work; cron responses include resolved run mode; error logging made configurable and more consistent.

* **Tests**
  * Comprehensive tests covering mode resolution, auth, control-flow permutations, and error paths.

* **Documentation**
  * Notion CMS docs updated with configuration, overrides, and cron behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->