### PR TITLE
Security: remediate dependency alerts and harden Notion request URL handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3394,13 +3394,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -3716,10 +3716,11 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -5734,9 +5735,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.1.tgz",
+      "integrity": "sha512-IxfVbRFVlV8V/yRaGzk0UVIcsKKHMSfYw66T/u4nTwlWteQePsxe//LjudR1AMX4tZW3WFCh3Zqa/sjlqpbURQ==",
       "dev": true,
       "license": "ISC"
     },
@@ -8415,10 +8416,11 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -9617,9 +9619,10 @@
       "peer": true
     },
     "node_modules/prismjs": {
-      "version": "1.27.0",
-      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.27.0.tgz",
-      "integrity": "sha512-t13BGPUlFDR7wRB5kQDG4jjl7XeuH6jbJGt11JHPL96qwsEHNX2+68tFXqc1/k+/jALsbSWJKUOT/hcYAZ5LkA==",
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
+      "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==",
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -11014,9 +11017,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.22.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.22.0.tgz",
-      "integrity": "sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg==",
+      "version": "7.24.2",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.2.tgz",
+      "integrity": "sha512-P9J1HWYV/ajFr8uCqk5QixwiRKmB1wOamgS0e+o2Z4A44Ej2+thFVRLG/eA7qprx88XXhnV5Bl8LHXTURpzB3Q==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "vitest": "^4.0.17"
   },
   "overrides": {
+    "prismjs": "1.30.0",
     "@types/react": "19.2.14",
     "@types/react-dom": "19.2.3"
   }

--- a/src/lib/cms/notion/client.test.ts
+++ b/src/lib/cms/notion/client.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { NotionConfigError } from '@/lib/cms/notion/errors'
+import { notionRequest } from '@/lib/cms/notion/client'
+
+describe('notionRequest', () => {
+  beforeEach(() => {
+    process.env.NOTION_API_TOKEN = 'test-token'
+    process.env.NOTION_API_VERSION = '2025-09-03'
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('builds a safe Notion API URL for allowed paths', async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(
+        new Response(JSON.stringify({ ok: true }), { status: 200 }),
+      )
+
+    await notionRequest('/pages/abc123', { method: 'GET', maxRetries: 0 })
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      'https://api.notion.com/v1/pages/abc123',
+      expect.objectContaining({ method: 'GET' }),
+    )
+  })
+
+  it('rejects absolute or cross-origin request paths', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch')
+
+    await expect(
+      notionRequest('//evil.example.com/path', {
+        method: 'GET',
+        maxRetries: 0,
+      }),
+    ).rejects.toBeInstanceOf(NotionConfigError)
+
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+})

--- a/src/lib/cms/notion/client.test.ts
+++ b/src/lib/cms/notion/client.test.ts
@@ -28,6 +28,24 @@ describe('notionRequest', () => {
     )
   })
 
+  it('preserves query strings in allowed Notion API paths', async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(
+        new Response(JSON.stringify({ results: [] }), { status: 200 }),
+      )
+
+    await notionRequest('/blocks/abc123/children?page_size=100', {
+      method: 'GET',
+      maxRetries: 0,
+    })
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      'https://api.notion.com/v1/blocks/abc123/children?page_size=100',
+      expect.objectContaining({ method: 'GET' }),
+    )
+  })
+
   it('rejects absolute or cross-origin request paths', async () => {
     const fetchSpy = vi.spyOn(globalThis, 'fetch')
 

--- a/src/lib/cms/notion/client.ts
+++ b/src/lib/cms/notion/client.ts
@@ -125,8 +125,13 @@ function buildNotionRequestUrl(path: string): string {
     throw new NotionConfigError(`Blocked unsafe Notion request path: ${path}`)
   }
 
+  const [pathWithoutQuery, ...queryParts] = path.split('?')
+  const query = queryParts.join('?')
+
   const url = new URL(NOTION_BASE_URL)
-  url.pathname = `${url.pathname.replace(/\/$/, '')}${path}`
+  url.pathname = `${url.pathname.replace(/\/$/, '')}${pathWithoutQuery}`
+  url.search = query ? `?${query}` : ''
+  url.hash = ''
   if (url.origin !== NOTION_API_ORIGIN || !url.pathname.startsWith('/v1/')) {
     throw new NotionConfigError(`Blocked unsafe Notion request path: ${path}`)
   }

--- a/src/lib/cms/notion/client.ts
+++ b/src/lib/cms/notion/client.ts
@@ -1,6 +1,7 @@
 import { NotionConfigError, NotionHttpError } from '@/lib/cms/notion/errors'
 
 const NOTION_BASE_URL = 'https://api.notion.com/v1'
+const NOTION_API_ORIGIN = new URL(NOTION_BASE_URL).origin
 const DEFAULT_NOTION_VERSION = '2025-09-03'
 const NOTION_REQUEST_TIMEOUT_MS = 15_000
 
@@ -113,11 +114,32 @@ export function parseDataSourceId(value: string | undefined, envName: string) {
     : value
 }
 
+function buildNotionRequestUrl(path: string): string {
+  if (!path.startsWith('/')) {
+    throw new NotionConfigError(
+      `Notion request path must start with "/": ${path}`,
+    )
+  }
+
+  if (path.startsWith('//') || path.includes('..')) {
+    throw new NotionConfigError(`Blocked unsafe Notion request path: ${path}`)
+  }
+
+  const url = new URL(NOTION_BASE_URL)
+  url.pathname = `${url.pathname.replace(/\/$/, '')}${path}`
+  if (url.origin !== NOTION_API_ORIGIN || !url.pathname.startsWith('/v1/')) {
+    throw new NotionConfigError(`Blocked unsafe Notion request path: ${path}`)
+  }
+
+  return url.toString()
+}
+
 export async function notionRequest<T>(
   path: string,
   options: NotionRequestOptions,
 ): Promise<T> {
   const config = ensureNotionConfig()
+  const requestUrl = buildNotionRequestUrl(path)
   const maxRetries = options.maxRetries ?? 5
 
   for (let attempt = 0; attempt <= maxRetries; attempt += 1) {
@@ -129,7 +151,7 @@ export async function notionRequest<T>(
     let response: Response
 
     try {
-      response = await fetch(`${NOTION_BASE_URL}${path}`, {
+      response = await fetch(requestUrl, {
         method: options.method,
         headers: {
           Authorization: `Bearer ${config.apiToken}`,


### PR DESCRIPTION
## Summary
- harden Notion API request URL construction with explicit path validation and origin/path enforcement
- add regression tests for allowed and blocked Notion request paths
- remediate vulnerable transitive dependency versions in lockfile (undici, minimatch)
- pin prismjs via npm overrides to remove DOM clobbering advisory in the current markdown highlighting chain

## Validation
- npm audit --json (0 vulnerabilities)
- npm run lint (no errors)
- npm run typecheck
- npm test
- npx vitest run src/lib/cms/notion/client.test.ts

## Alert handling notes
- Code scanning js/request-forgery is mitigated by request path validation before fetch URL assembly.
- Code scanning js/weak-cryptographic-algorithm in Cloudinary signing likely remains a policy false positive because Cloudinary signatures require SHA-1 by spec. Recommend dismissing with rationale unless we migrate to SDK-managed signing abstraction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Pinned Prismjs dependency to version 1.30.0

* **Bug Fixes / Reliability**
  * Improved Notion API request validation to prevent unsafe URLs and surface configuration errors earlier
  * Enhanced error handling for Notion requests to make failures more predictable

* **Tests**
  * Added unit tests covering Notion request validation, query handling, and error scenarios
<!-- end of auto-generated comment: release notes by coderabbit.ai -->