### PR TITLE
Batch Notion webhook syncs and add Notion integration/agent docs

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -43,6 +43,8 @@ Optional env vars:
 - Preserve header search UX (`Cmd/Ctrl + K`) and debounced matching over article body text.
 - Hermes chat must keep streaming behavior and markdown rendering compatibility.
 - Prefer project-local icons in `src/icons` when matching existing visual language; use Heroicons selectively where already adopted.
+- Treat Notion `Governance Hub` as the canonical index for governance/contracts/runbooks and related CMS source databases.
+- For reconciliation/drift/cleanup/integrity operations, log evidence in Notion `Operations Runs`.
 
 ## Code Documentation Expectations
 
@@ -91,3 +93,5 @@ Optional env vars:
 - Ongoing upkeep tasks: `docs/MAINTENANCE.md`
 - Documentation standards: `docs/DOCUMENTATION.md`
 - Notion CMS setup and runbook: `docs/NOTION_CMS.md`
+- Notion runtime integration (current state): `docs/notion-integration.md`
+- Agent Notion operations playbook: `docs/agent-notion-operations.md`

--- a/README.md
+++ b/README.md
@@ -244,6 +244,8 @@ Detailed topic docs live in `docs/`:
 - `docs/MAINTENANCE.md`
 - `docs/DOCUMENTATION.md`
 - `docs/NOTION_CMS.md`
+- `docs/notion-integration.md`
+- `docs/agent-notion-operations.md`
 
 If you need implementation internals first, start with:
 

--- a/docs/DOCUMENTATION.md
+++ b/docs/DOCUMENTATION.md
@@ -5,7 +5,9 @@
 - `README.md` = onboarding and runtime usage.
 - `.github/copilot-instructions.md` = concise AI-agent operating guide.
 - `docs/*.md` = deep references by concern (architecture, styling, SEO, etc.).
-- `docs/NOTION_CMS.md` = Notion-specific configuration and operations runbook.
+- `docs/NOTION_CMS.md` = Notion-specific setup and operational runbook.
+- `docs/notion-integration.md` = current Notion runtime architecture and integration contracts.
+- `docs/agent-notion-operations.md` = agent execution playbook for Notion MCP/Cloudinary MCP/image workflows.
 - `docs/PORTFOLIO_BACKLOG.md` = portfolio engineering backlog operations and Notion backlog sync workflow.
 
 ## Progressive Disclosure Rule

--- a/docs/NOTION_CMS.md
+++ b/docs/NOTION_CMS.md
@@ -4,6 +4,11 @@
 
 Operational setup and runbook for the Notion-backed CMS runtime.
 
+Related references:
+
+- `docs/notion-integration.md` for current runtime architecture and contracts.
+- `docs/agent-notion-operations.md` for agent execution workflow using Notion MCP, Cloudinary MCP, and image tooling.
+
 ## Provider mode
 
 - `CMS_PROVIDER=notion`: uses Notion CMS repositories for articles, pages, projects, tech, uses, and site settings.

--- a/docs/agent-notion-operations.md
+++ b/docs/agent-notion-operations.md
@@ -1,0 +1,134 @@
+# Agent Notion Operations
+
+## Purpose
+
+Agent-facing playbook for working with Notion-backed CMS workflows in BP Portfolio using Notion MCP, Cloudinary MCP, and Codex image tooling.
+
+Use this document for operational execution. Use `docs/notion-integration.md` for runtime architecture details.
+
+## Tooling Roles
+
+### Notion MCP
+
+Use for:
+
+- Reading/writing CMS records and SOP pages.
+- Inspecting data source schemas before updates.
+- Moving/reorganizing pages/databases.
+- Logging operations evidence.
+
+Primary expectation:
+
+- Always fetch schema/context first, then write.
+
+### Cloudinary MCP
+
+Use for:
+
+- Managing asset metadata/tags/folders.
+- Asset inventory/search and lifecycle cleanup.
+- Administrative operations that should not be done via ad-hoc URL edits.
+
+Primary expectation:
+
+- Treat Cloudinary as the media system of record for assets, but keep article/content truth in Notion source records.
+
+### Codex Image Skill (`$imagegen`)
+
+Use for:
+
+- Generating/editing image candidates (for covers or visual assets) via OpenAI image APIs.
+
+Primary expectation:
+
+- Generation is not publication. Persist winning assets and metadata back through the approved Notion/Cloudinary workflow.
+
+## Canonical Data Rules
+
+1. Source content data source owns article authoring/editorial truth.
+2. `Portfolio CMS - Articles` is projection/read-model output.
+3. `Source Article` page blocks are canonical article body source.
+4. Do not manually force publish state by editing projection records.
+5. Keep Notion API version pinned to `NOTION_API_VERSION=2025-09-03`.
+
+## Standard Agent Workflow
+
+1. Identify the operation type.
+
+- Content/source edit, projection maintenance, governance doc update, or asset workflow.
+
+2. Read before write.
+
+- Fetch target page/data source.
+- Confirm schema and required fields.
+- Confirm whether target is canonical or derived.
+
+3. Apply minimal scoped changes.
+
+- Prefer single-record/single-page edits when possible.
+- Avoid broad destructive operations.
+
+4. Verify immediately.
+
+- Re-fetch changed pages/rows.
+- Confirm expected fields, status, and relations.
+
+5. Log when operational.
+
+- For reconciliation/drift/cleanup/integrity activities, log evidence in Notion `Operations Runs`.
+
+## Playbooks
+
+### A) Update a canonical CMS record
+
+1. Fetch target data source schema.
+2. Locate the row (by title/slug/id).
+3. Update only canonical fields.
+4. Re-fetch and confirm persisted values.
+5. If projection-dependent, trigger sync endpoint or wait for webhook sync and verify.
+
+### B) Article projection maintenance
+
+1. Treat source content row as the only publish-control plane.
+2. Use `/api/cms/sync/articles` or reconciliation endpoints for projection fixes.
+3. Never use projection row manual edits as a substitute for source fixes.
+4. Confirm `Source Article` relation and mapped fields after sync.
+
+### C) Governance and SOP operations
+
+1. Use `Governance Hub` as the canonical governance index.
+2. Keep SOP run evidence in `Operations Runs`.
+3. Prefer moving artifacts to the right container over duplicating docs.
+
+### D) Cover/image workflow (agentic)
+
+1. Generate candidates with `$imagegen` only when needed.
+2. Upload/store winning assets in Cloudinary with policy-aligned foldering/tags.
+3. Persist final asset URL/selection fields in source Notion records.
+4. Run projection sync if the updated metadata should appear in delivery surfaces.
+5. Log operational runs or exceptions in `Operations Runs`.
+
+## Guardrails
+
+- Do not overwrite canonical article body in projection structures.
+- Do not rewrite unrelated SOP content while performing operational edits.
+- Do not delete child pages/databases during Notion `replace_content` actions unless explicitly approved.
+- When Notion validation errors list child-content deletion risk, stop and switch to targeted `update_content` edits.
+- Prefer explicit dates and status values when writing operational logs.
+
+## Suggested Run Log Minimum (Operations Runs)
+
+For each operational run, capture:
+
+- `Run` (title)
+- `Run Type`
+- `Run Date`
+- `Status`
+- `Source Asset` (URL to report/SOP/run page)
+- `Notes` (brief outcome and follow-up)
+
+## Related References
+
+- Runtime architecture: `docs/notion-integration.md`
+- Setup + endpoint runbook: `docs/NOTION_CMS.md`
+- Project-wide rules: `AGENTS.md`

--- a/docs/notion-integration.md
+++ b/docs/notion-integration.md
@@ -1,0 +1,128 @@
+# Notion Integration
+
+## Purpose
+
+Current-state reference for how BP Portfolio integrates with Notion at runtime, including data ownership, API surfaces, and operational guardrails.
+
+## Provider Model
+
+- `CMS_PROVIDER=notion`: app reads CMS content from Notion repositories.
+- `CMS_PROVIDER=local`: app uses local fallback content and must still render safe empty states for CMS-first surfaces.
+
+Provider resolution is handled by `src/lib/cms/provider.ts`.
+
+## Required Runtime Baseline
+
+- `NOTION_API_VERSION` must remain pinned to `2025-09-03`.
+- Notion client and request safeguards are implemented in `src/lib/cms/notion/client.ts`.
+- Core CMS cache policy/tags are defined in `src/lib/cms/cache.ts`.
+
+## Data Sources in Use
+
+Configured via env vars in `src/lib/cms/notion/config.ts`.
+
+Core:
+
+- `NOTION_CMS_ARTICLES_DATA_SOURCE`
+- `NOTION_CMS_PAGES_DATA_SOURCE`
+- `NOTION_CMS_PROJECTS_DATA_SOURCE`
+- `NOTION_CMS_TECH_DATA_SOURCE`
+- `NOTION_CMS_USES_DATA_SOURCE`
+- `NOTION_CMS_WORK_HISTORY_DATA_SOURCE`
+- `NOTION_CMS_AUTHORS_DATA_SOURCE`
+- `NOTION_CMS_SITE_SETTINGS_DATA_SOURCE`
+- `NOTION_CMS_ROUTE_REGISTRY_DATA_SOURCE`
+- `NOTION_CONTENT_DB_DATA_SOURCE`
+
+Optional/operational:
+
+- `NOTION_CMS_WEBHOOK_EVENTS_DATA_SOURCE`
+- `NOTION_CMS_AUTOMATION_ERRORS_DATA_SOURCE`
+- `NOTION_IMAGE_JOBS_DATA_SOURCE`
+- `NOTION_CONTENT_CALENDAR_DATA_SOURCE`
+
+## Canonical Contracts
+
+### Article Source of Truth
+
+- Canonical article body comes from `Source Article` page blocks (Notion block tree), not from projection body fields.
+- Content authoring/editorial state belongs to the source content data source.
+
+### Projection Contract
+
+- `Portfolio CMS - Articles` is a delivery/read model.
+- Projection sync is one-way from source content to projection.
+- Agents/operators should not manually edit projection rows to force publishing behavior.
+
+### URL Contract
+
+- Canonical site URL should resolve from CMS site settings (`canonicalUrl`) when present.
+- Fallback is `NEXT_PUBLIC_SITE_URL`.
+
+## Runtime Read Paths
+
+Primary repository layer lives in `src/lib/cms/*Repo.ts` and is protected with `unstable_cache` plus `CMS_TAGS`.
+
+Main reads:
+
+- Articles/search/article detail: `src/lib/cms/articlesRepo.ts`
+- CMS pages: `src/lib/cms/pagesRepo.ts`
+- Site settings: `src/lib/cms/siteSettingsRepo.ts`
+- Navigation: `src/lib/cms/navigationRepo.ts`
+- Projects/Tech/Uses/Work History/Authors: corresponding repos under `src/lib/cms/`
+
+## Runtime Write and Sync Paths
+
+### Notion Webhook
+
+`POST /api/webhooks/notion` (`src/app/api/webhooks/notion/route.ts`):
+
+- Verifies Notion signature (`X-Notion-Signature`) and supports setup token handshake.
+- Applies cache/path revalidation via tags and route invalidation.
+- Runs projection sync for eligible events when enabled.
+- Uses durable dedupe/claim flow when webhook ledger data source is configured.
+
+### Manual/Automation Sync APIs
+
+`/api/cms/sync/articles/*` endpoints are the operational write surface for projection maintenance:
+
+- `/api/cms/sync/articles`
+- `/api/cms/sync/articles/reconcile`
+- `/api/cms/sync/articles/replay-failures`
+- `/api/cms/sync/articles/watchdog`
+- `/api/cms/sync/articles/prepublish-gate`
+- `/api/cms/sync/articles/quality-gate`
+- `/api/cms/sync/articles/auto-heal`
+- `/api/cms/sync/articles/cover-regeneration`
+
+All require `CMS_REVALIDATE_SECRET` authorization checks.
+
+### Cron Orchestration
+
+Cron endpoints under `src/app/api/cron/*` coordinate integrity, sync, cleanup, and maintenance.
+They are protected by `CRON_SECRET` (or fallback `CMS_REVALIDATE_SECRET`).
+
+## Revalidation Model
+
+- Canonical tag registry: `CMS_TAGS` in `src/lib/cms/cache.ts`.
+- Notion webhook events call `revalidateTag(...)` and selected `revalidatePath(...)` for critical surfaces (`/`, `/articles`, `/projects`, `/tech`, `/uses`, sitemap/feed/llms routes).
+
+## Failure Behavior
+
+- If Notion is unavailable/misconfigured, repos catch `NotionConfigError`/`NotionHttpError` and fall back to safe local behavior where implemented.
+- Webhook processing is fail-open for some missing metadata cases to avoid blocking updates, while logging diagnostics.
+- Projection sync failures are surfaced in API responses/logs and can be replayed with dedicated endpoints.
+
+## Governance and Operations References
+
+- Governance root: `Governance Hub` in Notion.
+- SOP run/evidence destination: `Operations Runs` database in Notion.
+- Operational SOP details remain in Engineering SOPs and `docs/NOTION_CMS.md`.
+
+## Change Checklist (When Modifying Integration)
+
+1. Confirm data ownership contract (source vs projection) is unchanged or intentionally updated.
+2. Update mapper/repo logic and corresponding env documentation together.
+3. Validate webhook signature and projection behavior in local/dev.
+4. Verify cache invalidation tags and route revalidation still cover affected surfaces.
+5. Update SOP references if operational workflow changes.

--- a/src/app/api/webhooks/notion/route.test.ts
+++ b/src/app/api/webhooks/notion/route.test.ts
@@ -141,6 +141,108 @@ describe('POST /api/webhooks/notion payload normalization', () => {
     })
   })
 
+  it('coalesces duplicate page sync work within one webhook payload', async () => {
+    mocks.claimWebhookEvent
+      .mockResolvedValueOnce({
+        action: 'claimed',
+        ledgerPageId: 'ledger-a',
+      })
+      .mockResolvedValueOnce({
+        action: 'claimed',
+        ledgerPageId: 'ledger-b',
+      })
+
+    const request = new Request('http://localhost/api/webhooks/notion', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        events: [
+          {
+            id: 'evt-batch-1',
+            type: 'page.content_updated',
+            data: {
+              id: 'page-shared-id',
+            },
+          },
+          {
+            id: 'evt-batch-2',
+            type: 'page.content_updated',
+            data: {
+              id: 'page-shared-id',
+            },
+          },
+        ],
+      }),
+    })
+
+    const response = await POST(request)
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(mocks.syncPortfolioArticleProjection).toHaveBeenCalledTimes(1)
+    expect(mocks.syncPortfolioArticleProjection).toHaveBeenCalledWith({
+      pageId: 'page-shared-id',
+    })
+    expect(mocks.completeWebhookEventClaim).toHaveBeenCalledTimes(2)
+    expect(body.diagnostics).toMatchObject({
+      receivedEvents: 2,
+      processedEvents: 2,
+      syncAttempts: 1,
+      syncSuccesses: 1,
+      syncFailures: 0,
+    })
+  })
+
+  it('prefers a single full sync when payload includes data_source.content_updated', async () => {
+    mocks.claimWebhookEvent
+      .mockResolvedValueOnce({
+        action: 'claimed',
+        ledgerPageId: 'ledger-page-event',
+      })
+      .mockResolvedValueOnce({
+        action: 'claimed',
+        ledgerPageId: 'ledger-full-event',
+      })
+
+    const request = new Request('http://localhost/api/webhooks/notion', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        events: [
+          {
+            id: 'evt-mixed-page',
+            type: 'page.content_updated',
+            data: {
+              id: 'page-mixed-id',
+            },
+          },
+          {
+            id: 'evt-mixed-full',
+            type: 'data_source.content_updated',
+            entity: {
+              id: '221be01e-1e06-8089-99b0-000b6415ee9e',
+            },
+          },
+        ],
+      }),
+    })
+
+    const response = await POST(request)
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(mocks.syncPortfolioArticleProjection).toHaveBeenCalledTimes(1)
+    expect(mocks.syncPortfolioArticleProjection).toHaveBeenCalledWith(undefined)
+    expect(mocks.completeWebhookEventClaim).toHaveBeenCalledTimes(2)
+    expect(body.diagnostics).toMatchObject({
+      receivedEvents: 2,
+      processedEvents: 2,
+      syncAttempts: 1,
+      syncSuccesses: 1,
+      syncFailures: 0,
+    })
+  })
+
   it('returns verified response for verification token handshake payloads', async () => {
     process.env.NOTION_WEBHOOK_VERIFICATION_TOKEN = 'verify-me'
 

--- a/src/app/api/webhooks/notion/route.ts
+++ b/src/app/api/webhooks/notion/route.ts
@@ -533,6 +533,9 @@ export async function POST(request: Request) {
       continue
     }
 
+    // syncKey groups events into pendingSyncByKey so we can coalesce processing:
+    // CONTENT_UPDATED_EVENT uses FULL_SYNC_KEY (global/full sync bucket), while
+    // other events use page:${resolvedEntityId} (per-page bucket).
     const syncKey =
       eventType === CONTENT_UPDATED_EVENT
         ? FULL_SYNC_KEY

--- a/src/app/api/webhooks/notion/route.ts
+++ b/src/app/api/webhooks/notion/route.ts
@@ -49,6 +49,137 @@ function normalizeEvents(payload: NotionWebhookPayload): NotionWebhookEvent[] {
 }
 
 const EVENT_TTL_MS = 24 * 60 * 60 * 1000
+const PAGE_MUTATION_EVENTS = new Set([
+  'page.created',
+  'page.properties_updated',
+  'page.content_updated',
+  'page.deleted',
+  'page.undeleted',
+  'page.moved',
+])
+const CONTENT_UPDATED_EVENT = 'data_source.content_updated'
+const SCHEMA_UPDATED_EVENT = 'data_source.schema_updated'
+const DATA_SOURCE_NAV_EVENTS = new Set([
+  'data_source.created',
+  'data_source.deleted',
+  'data_source.moved',
+  'data_source.undeleted',
+])
+const FULL_SYNC_KEY = '__full_sync__'
+
+type RevalidationPlan = {
+  tags: Set<string>
+  paths: Set<string>
+}
+
+type PendingSyncRequest = {
+  eventType: string
+  resolvedEntityId?: string
+  ledgerPageId?: string
+}
+
+function isCommentEvent(eventType: string) {
+  return eventType === 'comment.created' || eventType.startsWith('comment.')
+}
+
+function isPageMutationEvent(eventType: string) {
+  return PAGE_MUTATION_EVENTS.has(eventType)
+}
+
+function isDataSourceNavigationEvent(eventType: string) {
+  return (
+    DATA_SOURCE_NAV_EVENTS.has(eventType) || eventType.startsWith('database.')
+  )
+}
+
+function isProjectionCandidateEvent(eventType: string) {
+  return isPageMutationEvent(eventType) || eventType === CONTENT_UPDATED_EVENT
+}
+
+function createRevalidationPlan(): RevalidationPlan {
+  return {
+    tags: new Set<string>(),
+    paths: new Set<string>(),
+  }
+}
+
+function addTag(plan: RevalidationPlan, tag: string) {
+  plan.tags.add(tag)
+}
+
+function addPath(plan: RevalidationPlan, path: string) {
+  plan.paths.add(path)
+}
+
+function queueCommonCmsTags(plan: RevalidationPlan) {
+  addTag(plan, CMS_TAGS.articles)
+  addTag(plan, CMS_TAGS.projects)
+  addTag(plan, CMS_TAGS.tech)
+  addTag(plan, CMS_TAGS.uses)
+  addTag(plan, CMS_TAGS.workHistory)
+  addTag(plan, CMS_TAGS.pages)
+}
+
+function queueContentDiscoveryPaths(plan: RevalidationPlan) {
+  addPath(plan, '/sitemap.xml')
+  addPath(plan, '/feed.xml')
+  addPath(plan, '/llms.txt')
+  addPath(plan, '/llms-full.txt')
+}
+
+function queuePrimaryContentPaths(plan: RevalidationPlan) {
+  addPath(plan, '/')
+  addPath(plan, '/about')
+  addPath(plan, '/articles')
+  addPath(plan, '/projects')
+  addPath(plan, '/tech')
+  addPath(plan, '/uses')
+}
+
+function collectEventRevalidation(eventType: string, plan: RevalidationPlan) {
+  if (isCommentEvent(eventType)) {
+    return
+  }
+
+  if (isPageMutationEvent(eventType)) {
+    queueCommonCmsTags(plan)
+    queuePrimaryContentPaths(plan)
+    queueContentDiscoveryPaths(plan)
+    return
+  }
+
+  if (eventType === CONTENT_UPDATED_EVENT) {
+    queueCommonCmsTags(plan)
+    queueContentDiscoveryPaths(plan)
+    return
+  }
+
+  if (eventType === SCHEMA_UPDATED_EVENT) {
+    console.warn(
+      '[cms:notion:webhook] Data source schema updated, verify mapper compatibility',
+    )
+    addTag(plan, CMS_TAGS.articles)
+    addTag(plan, CMS_TAGS.pages)
+    addTag(plan, CMS_TAGS.settings)
+    addTag(plan, CMS_TAGS.navigation)
+    return
+  }
+
+  if (isDataSourceNavigationEvent(eventType)) {
+    addTag(plan, CMS_TAGS.navigation)
+    addTag(plan, CMS_TAGS.settings)
+  }
+}
+
+function applyRevalidationPlan(plan: RevalidationPlan) {
+  for (const tag of plan.tags) {
+    revalidateTag(tag, 'max')
+  }
+  for (const path of plan.paths) {
+    revalidatePath(path)
+  }
+}
+
 // Best-effort fast-path dedupe for duplicate events in the same process instance.
 // In serverless/multi-instance deployments this map is not shared, so canonical
 // distributed dedupe still relies on claimWebhookEvent + ledger state in Notion.
@@ -84,92 +215,12 @@ function verifySignature(
   return timingSafeEqual(expectedBuffer, providedBuffer)
 }
 
-function applyEventRevalidation(eventType: string) {
-  if (eventType === 'comment.created' || eventType.startsWith('comment.')) {
-    return
-  }
-
-  if (
-    eventType === 'page.created' ||
-    eventType === 'page.properties_updated' ||
-    eventType === 'page.content_updated' ||
-    eventType === 'page.deleted' ||
-    eventType === 'page.undeleted' ||
-    eventType === 'page.moved'
-  ) {
-    revalidateTag(CMS_TAGS.articles, 'max')
-    revalidateTag(CMS_TAGS.projects, 'max')
-    revalidateTag(CMS_TAGS.tech, 'max')
-    revalidateTag(CMS_TAGS.uses, 'max')
-    revalidateTag(CMS_TAGS.workHistory, 'max')
-    revalidateTag(CMS_TAGS.pages, 'max')
-
-    revalidatePath('/')
-    revalidatePath('/about')
-    revalidatePath('/articles')
-    revalidatePath('/projects')
-    revalidatePath('/tech')
-    revalidatePath('/uses')
-    revalidatePath('/sitemap.xml')
-    revalidatePath('/feed.xml')
-    revalidatePath('/llms.txt')
-    revalidatePath('/llms-full.txt')
-
-    return
-  }
-
-  if (eventType === 'data_source.content_updated') {
-    revalidateTag(CMS_TAGS.articles, 'max')
-    revalidateTag(CMS_TAGS.projects, 'max')
-    revalidateTag(CMS_TAGS.tech, 'max')
-    revalidateTag(CMS_TAGS.uses, 'max')
-    revalidateTag(CMS_TAGS.workHistory, 'max')
-    revalidateTag(CMS_TAGS.pages, 'max')
-    revalidatePath('/sitemap.xml')
-    revalidatePath('/feed.xml')
-    revalidatePath('/llms.txt')
-    revalidatePath('/llms-full.txt')
-    return
-  }
-
-  if (eventType === 'data_source.schema_updated') {
-    console.warn(
-      '[cms:notion:webhook] Data source schema updated, verify mapper compatibility',
-    )
-    revalidateTag(CMS_TAGS.articles, 'max')
-    revalidateTag(CMS_TAGS.pages, 'max')
-    revalidateTag(CMS_TAGS.settings, 'max')
-    revalidateTag(CMS_TAGS.navigation, 'max')
-    return
-  }
-
-  if (
-    eventType === 'data_source.created' ||
-    eventType === 'data_source.deleted' ||
-    eventType === 'data_source.moved' ||
-    eventType === 'data_source.undeleted' ||
-    eventType.startsWith('database.')
-  ) {
-    revalidateTag(CMS_TAGS.navigation, 'max')
-    revalidateTag(CMS_TAGS.settings, 'max')
-    return
-  }
-}
-
 function shouldRunProjectionSync(eventType: string) {
   if (process.env.NOTION_ENABLE_ARTICLE_PROJECTION_SYNC === 'false') {
     return false
   }
 
-  return (
-    eventType === 'page.created' ||
-    eventType === 'page.properties_updated' ||
-    eventType === 'page.content_updated' ||
-    eventType === 'page.deleted' ||
-    eventType === 'page.undeleted' ||
-    eventType === 'page.moved' ||
-    eventType === 'data_source.content_updated'
-  )
+  return isProjectionCandidateEvent(eventType)
 }
 
 function getContentDataSourceIdSafe() {
@@ -209,7 +260,7 @@ function getEventDataSourceId(event: NotionWebhookEvent): string | null {
     return parentDataSourceId
   }
 
-  if (event.type === 'data_source.content_updated') {
+  if (event.type === CONTENT_UPDATED_EVENT) {
     const entityId =
       event.entity && typeof event.entity.id === 'string'
         ? event.entity.id
@@ -369,6 +420,8 @@ export async function POST(request: Request) {
     syncSuccesses: 0,
     syncFailures: 0,
   }
+  const revalidationPlan = createRevalidationPlan()
+  const pendingSyncByKey = new Map<string, PendingSyncRequest[]>()
 
   for (const event of events) {
     if (typeof event !== 'object' || event === null) {
@@ -444,7 +497,7 @@ export async function POST(request: Request) {
       }
     }
 
-    applyEventRevalidation(eventType)
+    collectEventRevalidation(eventType, revalidationPlan)
 
     const shouldSyncThisEvent = shouldRunProjectionForEvent(
       eventType,

--- a/src/app/api/webhooks/notion/route.ts
+++ b/src/app/api/webhooks/notion/route.ts
@@ -533,43 +533,83 @@ export async function POST(request: Request) {
       continue
     }
 
+    const syncKey =
+      eventType === CONTENT_UPDATED_EVENT
+        ? FULL_SYNC_KEY
+        : `page:${resolvedEntityId}`
+    const pending = pendingSyncByKey.get(syncKey) ?? []
+    pending.push({
+      eventType,
+      resolvedEntityId,
+      ledgerPageId: ledgerPageId || undefined,
+    })
+    pendingSyncByKey.set(syncKey, pending)
+  }
+
+  applyRevalidationPlan(revalidationPlan)
+
+  if (pendingSyncByKey.has(FULL_SYNC_KEY)) {
+    const fullSyncRequests = pendingSyncByKey.get(FULL_SYNC_KEY) ?? []
+    for (const [syncKey, requests] of pendingSyncByKey) {
+      if (syncKey === FULL_SYNC_KEY) {
+        continue
+      }
+      fullSyncRequests.push(...requests)
+      pendingSyncByKey.delete(syncKey)
+    }
+    pendingSyncByKey.set(FULL_SYNC_KEY, fullSyncRequests)
+  }
+
+  for (const [syncKey, pendingRequests] of pendingSyncByKey) {
+    const syncInput =
+      syncKey === FULL_SYNC_KEY
+        ? undefined
+        : { pageId: pendingRequests[0]?.resolvedEntityId }
+
     try {
       diagnostics.syncAttempts += 1
-      const syncResult = await syncPortfolioArticleProjection(
-        eventType === 'data_source.content_updated'
-          ? undefined
-          : { pageId: resolvedEntityId },
-      )
+      const syncResult = await syncPortfolioArticleProjection(syncInput)
       console.info('[cms:notion:webhook] projection sync', {
-        eventType,
-        entityId: resolvedEntityId,
+        syncKey,
+        syncInput,
         ...syncResult,
       })
 
       if (!syncResult.ok) {
         diagnostics.syncFailures += 1
-        if (ledgerPageId) {
-          await failWebhookEventClaim(
-            ledgerPageId,
-            syncResult.errors.map((entry) => entry.message).join('; '),
-          ).catch(() => {})
+        const errorMessage = syncResult.errors
+          .map((entry) => entry.message)
+          .join('; ')
+        for (const request of pendingRequests) {
+          if (!request.ledgerPageId) {
+            continue
+          }
+          await failWebhookEventClaim(request.ledgerPageId, errorMessage).catch(
+            () => {},
+          )
         }
       } else {
         diagnostics.syncSuccesses += 1
-        if (ledgerPageId) {
-          await completeWebhookEventClaim(ledgerPageId).catch(() => {})
+        for (const request of pendingRequests) {
+          if (!request.ledgerPageId) {
+            continue
+          }
+          await completeWebhookEventClaim(request.ledgerPageId).catch(() => {})
         }
       }
     } catch (error) {
       diagnostics.syncFailures += 1
       console.error('[cms:notion:webhook] projection sync failed', {
-        eventType,
-        entityId: resolvedEntityId,
+        syncKey,
+        syncInput,
         error: error instanceof Error ? error.message : 'Unknown error',
       })
-      if (ledgerPageId) {
+      for (const request of pendingRequests) {
+        if (!request.ledgerPageId) {
+          continue
+        }
         await failWebhookEventClaim(
-          ledgerPageId,
+          request.ledgerPageId,
           error instanceof Error ? error.message : 'Unknown error',
         ).catch(() => {})
       }


### PR DESCRIPTION
# Batches Notion webhook syncs + adds Notion integration/agent docs

## TL;DR

- Added two new Notion-focused docs to reduce agent confusion and onboarding friction.
- Updated project instruction/docs index so agents discover the right Notion docs fast.
- Refactored Notion webhook handling to coalesce revalidation and sync work per payload.
- Added regression tests for duplicate-event coalescing and full-sync precedence.

## Scope

- Documentation:
  - Added `docs/notion-integration.md`
  - Added `docs/agent-notion-operations.md`
  - Updated `.github/copilot-instructions.md`, `README.md`, `docs/DOCUMENTATION.md`, `docs/NOTION_CMS.md`
- Runtime behavior:
  - Refactored `src/app/api/webhooks/notion/route.ts`
  - Extended `src/app/api/webhooks/notion/route.test.ts`

### Key changes

- Introduced shared webhook event-category constants/helpers to avoid drift in event handling logic.
- Replaced per-event revalidation calls with a plan-based coalesced model (unique tags/paths).
- Coalesced projection sync calls within a webhook payload:
  - one sync per unique page target
  - one full sync for `data_source.content_updated`
- Added explicit full-sync precedence:
  - when a payload contains `data_source.content_updated`, page-level sync requests collapse into a single full sync.
- Added tests:
  - duplicate page events in one payload only trigger one sync call
  - mixed page + `data_source.content_updated` payload triggers one full sync call

## Why

- Fresh agents were getting confused by fragmented Notion guidance and mixed governance context.
- Webhook payloads could trigger redundant revalidation and sync operations under burst updates.
- This improves maintainability, reduces repeated work, and clarifies canonical Notion operating patterns.

## Risk / Mitigation

- **Risk:** Behavior change in webhook execution pattern (coalesced sync/revalidation) could alter operational observability expectations.
  **Mitigation:** Added targeted regression tests for coalescing + precedence; preserved ledger completion/failure semantics for all claimed events.

---

## How to Test (Reviewer Checklist)

1. Run webhook tests:
   - `npm run test -- src/app/api/webhooks/notion/route.test.ts`
2. Run lint on changed webhook files:
   - `npx eslint src/app/api/webhooks/notion/route.ts src/app/api/webhooks/notion/route.test.ts`
3. Sanity-check docs:
   - Confirm new docs exist and are linked from `README.md`, `.github/copilot-instructions.md`, and `docs/DOCUMENTATION.md`.

---

## Breaking Changes?

- [ ] Yes
- [x] No

---

## Release Notes

- Improved Notion webhook efficiency by batching duplicate sync/revalidation work.
- Added clear Notion integration and agent operations documentation for faster, safer onboarding.

## Rollback Plan

- Revert this PR commit range:
  - `git revert <sha-range>` (or revert PR in GitHub)
- If needed, specifically revert webhook behavior by restoring:
  - `src/app/api/webhooks/notion/route.ts`
  - `src/app/api/webhooks/notion/route.test.ts`
- Keep docs-only changes if desired, or revert doc files independently.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guides detailing Notion CMS runtime integration, operational playbooks, governance/operations logging, and expanded documentation index with new references

* **Refactor**
  * Improved webhook processing to coalesce related events and perform grouped projection syncs for fewer, more efficient sync operations

* **Tests**
  * Added tests covering webhook payload normalization and event coalescing scenarios
<!-- end of auto-generated comment: release notes by coderabbit.ai -->